### PR TITLE
short circuit from CGContext errors invalid context 0x0

### DIFF
--- a/ios/BVLinearGradientLayer.m
+++ b/ios/BVLinearGradientLayer.m
@@ -49,6 +49,11 @@
 - (void)display {
     [super display];
 
+    // short circuit when height or width are 0. Fixes CGContext errors throwing
+    if (self.bounds.size.height == 0 || self.bounds.size.width == 0) {
+      return;
+    }
+
     BOOL hasAlpha = NO;
 
     for (NSInteger i = 0; i < self.colors.count; i++) {


### PR DESCRIPTION
# Summary
Fixes #419 

`UIGraphicsBeginImageContextWithOptions` errors when height or width of the `CGRect` are 0. Had this happen in an animation, which ended up making it impossible to read my logs.

## Test Plan

Minor changes, tested locally

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [X] I have tested this on a device and a simulator
