### PR TITLE
Update readme to display the correct values syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ An optional array of numbers defining the location of each gradient color stop, 
 You may want to achieve an angled gradient effect, similar to those in image editors like Photoshop.
 One issue is that you have to calculate the angle based on the view's size, which only happens asynchronously and will cause unwanted flickr.
 
-In order to do that correctly you can set `{ useAngle: true, angle: 45, angleCenter: { x: 0.5, y: 0.5} }`, to achieve a gradient with a 45 degrees angle, with its center positioned in the view's exact center.
+In order to do that correctly you can set `useAngle={true} angle={45} angleCenter={{x:0.5,y:0.5}}`, to achieve a gradient with a 45 degrees angle, with its center positioned in the view's exact center.
 
 `useAngle` is used to turn on/off angle based calculation (as opposed to `start`/`end`).
 `angle` is the angle in degrees.


### PR DESCRIPTION
After using the react-native-linear-gradient i was unable to create a diagonal gradient with the syntax provided at the end of the README file,so here is the updated README with the correct syntax.

**Before:**
useAngle / angle / angleCenter

You may want to achieve an angled gradient effect, similar to those in image editors like Photoshop. One issue is that you have to calculate the angle based on the view's size, which only happens asynchronously and will cause unwanted flickr.

In order to do that correctly you can set `{ useAngle: true, angle: 45, angleCenter: { x: 0.5, y: 0.5}` }, to achieve a gradient with a 45 degrees angle, with its center positioned in the view's exact center.

useAngle is used to turn on/off angle based calculation (as opposed to start/end). angle is the angle in degrees. angleCenter is the center point of the angle (will control the weight and stretch of the gradient like it does in photoshop.

**Now:**
useAngle / angle / angleCenter

You may want to achieve an angled gradient effect, similar to those in image editors like Photoshop. One issue is that you have to calculate the angle based on the view's size, which only happens asynchronously and will cause unwanted flickr.

In order to do that correctly you can set `useAngle={true} angle={45} angleCenter={{x:0.5,y:0.5}}`, to achieve a gradient with a 45 degrees angle, with its center positioned in the view's exact center.

useAngle is used to turn on/off angle based calculation (as opposed to start/end). angle is the angle in degrees. angleCenter is the center point of the angle (will control the weight and stretch of the gradient like it does in photoshop.