### PR TITLE
Export LinearGradient as named export in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import LinearGradientIos from "./index.ios.js";
 import LinearGradientAndroid from "./index.android.js";
 import LinearGradientWindows from "./index.windows.js";
 
-const LinearGradient = Platform.OS === "ios"
+export const LinearGradient = Platform.OS === "ios"
   ? LinearGradientIos : Platform.OS === "android"
   ? LinearGradientAndroid : LinearGradientWindows;
 


### PR DESCRIPTION
A named export of LinearGradient is present in the typescript definition file (index.d.ts) but absent from the index.js implementation file.

This commit exports LinearGradient from index.js.