### PR TITLE
Update broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ You can see this component in action in [brentvatne/react-native-login](https://
 
 ### iOS build fails: library not found, "BVLinearGradient" was not found in the UIManager
 
-1. Ensure you have followed the [installations steps](https://github.com/react-native-community/react-native-linear-gradient#manual-link-steps-react-native--060) correctly. (`react-native link` for React Native < 0.60 and `npx pod-install` instead for > 0.60).
+1. Ensure you have followed the [installations steps](#installation) correctly. (`react-native link` for React Native < 0.60 and `npx pod-install` instead for > 0.60).
 2. Ensure `pod 'BVLinearGradient', :path => '../node_modules/react-native-linear-gradient'` is present in your `ios/Podfile`
 3. Ensure you use `ios/**.xcworkspace` file instead of `ios./**.xcodeproj`
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ On iOS you can use the `MaskedViewIOS` to display text with a gradient. The tric
 
 ### Animated Gradient
 
-Check out [Examples/AnimatedGradient](https://github.com/react-native-community/react-native-linear-gradient/blob/master/Examples/AnimatedGradient/src/index.js) (`git clone` this project, cd into it, npm install, open in Xcode and run) to see how this is done:
+Check out [Examples/AnimatedGradient](https://github.com/react-native-linear-gradient/react-native-linear-gradient/blob/master/Examples/AnimatedGradient/App.js) (`git clone` this project, cd into it, npm install, open in Xcode and run) to see how this is done:
 
 ![Example with extra props](https://raw.githubusercontent.com/react-native-community/react-native-linear-gradient/master/images/example-animated.gif)
 


### PR DESCRIPTION
Currently, "Examples/AnimatedGradient" and "installations steps" are broken links in the README - likely due to a rename from `react-native-community/react-native-linear-gradient` to `react-native-linear-gradient/react-native-linear-gradient`.
This PR updates those links :)