### PR TITLE
Add current latest release (2.5.6) in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # ChangeLog
 
-## 2.5.5
+## 2.5.6 - 2019-07-25
+
+- Just a re-release, because 2.5.5 installation was broken because of an npm bug
+
+## 2.5.5 - 2019-07-22
 
 - Change Flow types to work with newer versions of Flow.
 


### PR DESCRIPTION
Adds missing version and its changes, based on discussion found at https://github.com/react-native-linear-gradient/react-native-linear-gradient/commit/638b5de6bb0450cf84a293685990d6611b43a2d4