### PR TITLE
remove buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
-    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)


### PR DESCRIPTION
buildToolsVersion is no longer necessary, it'll default to Android Gradle Plugin version specification