### PR TITLE
Add PlatformColor support to Android

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
@@ -1,6 +1,8 @@
 package com.BV.LinearGradient;
 
+import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.uimanager.PixelUtil;
 
 import android.content.Context;
@@ -136,7 +138,10 @@ public class LinearGradientView extends View {
     public void setColors(ReadableArray colors) {
         int[] _colors = new int[colors.size()];
         for (int i = 0; i < _colors.length; i++) {
-            _colors[i] = colors.getInt(i);
+            _colors[i] =
+                    colors.getType(i) == ReadableType.Map
+                            ? ColorPropConverter.getColor(colors.getMap(i), getContext())
+                            : colors.getInt(i);
         }
         mColors = _colors;
         drawGradient();


### PR DESCRIPTION
Since version 0.63 React Native has supported [`PlatformColor`](https://reactnative.dev/docs/platformcolor) structs that among other features has dark mode support built in. This works fine on iOS but on Android it throws errors. 

This PR adds support for `PlatformColor` and since it relies on the ColorPropConverter class, I think it means minimum supported version of RN will be raised to 0.63 but that is a very old version so should be OK IMHO.