### PR TITLE
Fix useAngle logic to accurately render the angle

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
@@ -33,6 +33,96 @@ public class LinearGradientView extends View {
         super(context);
     }
 
+    /**
+     * Gets the point of the element that a line perpendicular to the gradient line
+     * intersects first. This will always be a corner.
+     *
+     * @param angle the gradient line angle, in cartesian degrees
+     * @param size  the size of the element
+     * @return the corner X and Y coordinates relative to the element center in cartesian
+     */
+    static private float[] getStartCornerToIntersect(float angle, int[] size) {
+        float halfWidth = size[0] / 2f;
+        float halfHeight = size[1] / 2f;
+        if (angle < 90f) {
+            // Bottom left
+            return new float[]{-halfWidth, -halfHeight};
+        } else if (angle < 180f) {
+            // Bottom right
+            return new float[]{halfWidth, -halfHeight};
+        } else if (angle < 270f) {
+            // Top right
+            return new float[]{halfWidth, halfHeight};
+        } else {
+            // Top left
+            return new float[]{-halfWidth, halfHeight};
+        }
+    }
+
+    /**
+     * Gets the start point assuming the angle is a multiple of 90 degrees
+     *
+     * @param angle the gradient line angle, in cartesian degrees
+     * @param size  the size of the element
+     * @return the start point, relative to the angle center in cartesian
+     */
+    static private float[] getHorizontalOrVerticalStartPoint(float angle, int[] size) {
+        float halfWidth = size[0] / 2f;
+        float halfHeight = size[1] / 2f;
+        if (angle == 0f) {
+            // Horizontal, left-to-right
+            return new float[]{-halfWidth, 0};
+        } else if (angle == 90f) {
+            // Vertical, bottom-to-top
+            return new float[]{0, -halfHeight};
+        } else if (angle == 180f) {
+            // Horizontal, right-to-left
+            return new float[]{halfWidth, 0};
+        } else {
+            // Vertical, top to bottom
+            return new float[]{0, halfHeight};
+        }
+    }
+
+    /**
+     * Gets the gradient start point for an angle
+     *
+     * @param angle the gradient line angle, in cartesian degrees
+     * @param size  the size of the element
+     * @return the start point X and Y coordinate, relative to the angle center in cartesian
+     */
+    static private float[] getGradientStartPoint(float angle, int[] size) {
+        // Bound angle to [0, 360)
+        angle = angle % 360f;
+        if (angle < 0f)
+            angle += 360f;
+
+        // Explicitly check for horizontal or vertical gradients, as slopes of
+        // the gradient line or a line perpendicular will be undefined in that case
+        if (angle % 90 == 0) {
+            return getHorizontalOrVerticalStartPoint(angle, size);
+        }
+
+        // Get the equivalent slope of the gradient line as tan = opposite/adjacent = y/x
+        float slope = (float) Math.tan(angle * Math.PI / 180.0f);
+
+        // Find the start point by computing the intersection of the gradient line
+        // and a line perpendicular to it that intersects the nearest corner
+        float perpendicularSlope = -1 / slope;
+
+        // Get the start corner to intersect relative to center, in cartesian space (+y = up)
+        float[] startCorner = getStartCornerToIntersect(angle, size);
+
+        // Compute b (of y = mx + b) to get the equation for the perpendicular line
+        float b = startCorner[1] - perpendicularSlope * startCorner[0];
+
+        // Solve the intersection of the gradient line and the perpendicular line:
+        float startX = b / (slope - perpendicularSlope);
+        float startY = slope * startX;
+
+        return new float[]{startX, startY};
+    }
+
     public void setStartPosition(ReadableArray startPos) {
         mStartPos = new float[]{(float) startPos.getDouble(0), (float) startPos.getDouble(1)};
         drawGradient();
@@ -93,44 +183,49 @@ public class LinearGradientView extends View {
         drawGradient();
     }
 
-    private float[] calculateGradientLocationWithAngle(float angle) {
-        float angleRad = (angle - 90.0f) * ((float)Math.PI / 180.0f);
-        float length = (float)Math.sqrt(2.0);
-
-        return new float[]{
-                (float) Math.cos(angleRad) * length,
-                (float) Math.sin(angleRad) * length
-        };
-    }
-
     private void drawGradient() {
         // guard against crashes happening while multiple properties are updated
         if (mColors == null || (mLocations != null && mColors.length != mLocations.length))
             return;
 
-        float[] startPos = mStartPos;
-        float[] endPos = mEndPos;
+        float[] startPos;
+        float[] endPos;
 
         if (mUseAngle && mAngleCenter != null) {
-            float[] angleSize = calculateGradientLocationWithAngle(mAngle);
+            // Angle is in bearing degrees (North = 0, East = 90)
+            // convert it to cartesian (N = 90, E = 0)
+            float angle = (90 - mAngle);
+            float[] relativeStartPoint = getGradientStartPoint(angle, mSize);
+
+            // Get true angleCenter
+            float[] angleCenter = new float[]{
+                    mAngleCenter[0] * mSize[0],
+                    mAngleCenter[1] * mSize[1]
+            };
+            // Translate to center on angle center
+            // Flip Y coordinate to convert from cartesian
             startPos = new float[]{
-                    mAngleCenter[0] - angleSize[0] / 2.0f,
-                    mAngleCenter[1] - angleSize[1] / 2.0f
+                    angleCenter[0] + relativeStartPoint[0],
+                    angleCenter[1] - relativeStartPoint[1]
             };
+            // Reflect across the center to get the end point
             endPos = new float[]{
-                    mAngleCenter[0] + angleSize[0] / 2.0f,
-                    mAngleCenter[1] + angleSize[1] / 2.0f
+                    angleCenter[0] - relativeStartPoint[0],
+                    angleCenter[1] + relativeStartPoint[1]
             };
+        } else {
+            startPos = new float[]{mStartPos[0] * mSize[0], mStartPos[1] * mSize[1]};
+            endPos = new float[]{mEndPos[0] * mSize[0], mEndPos[1] * mSize[1]};
         }
 
         mShader = new LinearGradient(
-                startPos[0] * mSize[0],
-                startPos[1] * mSize[1],
-                endPos[0] * mSize[0],
-                endPos[1] * mSize[1],
-            mColors,
-            mLocations,
-            Shader.TileMode.CLAMP);
+                startPos[0],
+                startPos[1],
+                endPos[0],
+                endPos[1],
+                mColors,
+                mLocations,
+                Shader.TileMode.CLAMP);
         mPaint.setShader(mShader);
         invalidate();
     }

--- a/ios/BVLinearGradientLayer.m
+++ b/ios/BVLinearGradientLayer.m
@@ -1,5 +1,6 @@
 #import "BVLinearGradientLayer.h"
 
+#include <math.h>
 #import <UIKit/UIKit.h>
 
 @implementation BVLinearGradientLayer
@@ -83,12 +84,69 @@
     [self setNeedsDisplay];
 }
 
-- (CGSize)calculateGradientLocationWithAngle:(CGFloat)angle
++ (CGPoint) getStartCornerToIntersectFromAngle:(CGFloat)angle AndSize:(CGSize)size
 {
-    CGFloat angleRad = (angle - 90) * (M_PI / 180);
-    CGFloat length = sqrt(2);
-    
-    return CGSizeMake(cos(angleRad) * length, sin(angleRad) * length);
+    float halfHeight = size.height / 2.0;
+    float halfWidth = size.width / 2.0;
+    if (angle < 90)
+        return CGPointMake(-halfWidth, -halfHeight);
+    else if (angle < 180)
+        return CGPointMake(halfWidth, -halfHeight);
+    else if (angle < 270)
+        return CGPointMake(halfWidth, halfHeight);
+    else
+        return CGPointMake(-halfWidth, halfHeight);
+}
+
++ (CGPoint) getHorizontalOrVerticalStartPointFromAngle:(CGFloat)angle AndSize:(CGSize)size
+{
+    float halfWidth = size.width / 2;
+    float halfHeight = size.height / 2;
+    if (angle == 0) {
+        // Horizontal, left-to-right
+        return CGPointMake(-halfWidth, 0);
+    } else if (angle == 90) {
+        // Vertical, bottom-to-top
+        return CGPointMake(0, -halfHeight);
+    } else if (angle == 180) {
+        // Horizontal, right-to-left
+        return CGPointMake(halfWidth, 0);
+    } else {
+        // Vertical, top to bottom
+        return CGPointMake(0, halfHeight);
+    }
+}
+
++ (CGPoint) getGradientStartPointFromAngle:(CGFloat)angle AndSize:(CGSize)size
+{
+    // Bound angle to [0, 360)
+    angle = fmodf(angle, 360);
+    if (angle < 0)
+        angle += 360;
+
+    // Explicitly check for horizontal or vertical gradients, as slopes of
+    // the gradient line or a line perpendicular will be undefined in that case
+    if (fmodf(angle, 90) == 0)
+        return [BVLinearGradientLayer getHorizontalOrVerticalStartPointFromAngle:angle AndSize:size];
+
+    // Get the equivalent slope of the gradient line as tan = opposite/adjacent = y/x
+    float slope = tan(angle * M_PI / 180.0);
+
+    // Find the start point by computing the intersection of the gradient line
+    // and a line perpendicular to it that intersects the nearest corner
+    float perpendicularSlope = -1 / slope;
+
+    // Get the start corner to intersect relative to center, in cartesian space (+y = up)
+    CGPoint startCorner = [BVLinearGradientLayer getStartCornerToIntersectFromAngle:angle AndSize:size];
+
+    // Compute b (of y = mx + b) to get the equation for the perpendicular line
+    float b = startCorner.y - perpendicularSlope * startCorner.x;
+
+    // Solve the intersection of the gradient line and the perpendicular line:
+    float startX = b / (slope - perpendicularSlope);
+    float startY = slope * startX;
+
+    return CGPointMake(startX, startY);
 }
     
 - (void)drawInContext:(CGContextRef)ctx
@@ -128,20 +186,41 @@
 
     free(locations);
 
-    CGPoint start = self.startPoint, end = self.endPoint;
+    CGPoint start, end;
     
     if (_useAngle)
     {
-        CGSize size = [self calculateGradientLocationWithAngle:_angle];
-        start.x = _angleCenter.x - size.width / 2;
-        start.y = _angleCenter.y - size.height / 2;
-        end.x = _angleCenter.x + size.width / 2;
-        end.y = _angleCenter.y + size.height / 2;
+        // Angle is in bearing degrees (North = 0, East = 90)
+        // convert it to cartesian (N = 90, E = 0)
+        float angle = (90 - _angle);
+        CGPoint relativeStartPoint = [BVLinearGradientLayer getGradientStartPointFromAngle:angle AndSize:size];
+
+        // Get true angleCenter
+        CGPoint angleCenter = CGPointMake(
+            _angleCenter.x * size.width,
+            _angleCenter.y * size.height
+        );
+        // Translate to center on angle center
+        // Flip Y coordinate to convert from cartesian
+        start = CGPointMake(
+            angleCenter.x + relativeStartPoint.x,
+            angleCenter.y - relativeStartPoint.y
+        );
+        // Reflect across the center to get the end point
+        end = CGPointMake(
+            angleCenter.x - relativeStartPoint.x,
+            angleCenter.y + relativeStartPoint.y
+        );
+    }
+    else
+    {
+        start = CGPointMake(self.startPoint.x * size.width, self.startPoint.y * size.height);
+        end = CGPointMake(self.endPoint.x * size.width, self.endPoint.y * size.height);
     }
     
     CGContextDrawLinearGradient(ctx, gradient,
-                                CGPointMake(start.x * size.width, start.y * size.height),
-                                CGPointMake(end.x * size.width, end.y * size.height),
+                                start,
+                                end,
                                 kCGGradientDrawsBeforeStartLocation | kCGGradientDrawsAfterEndLocation);
     CGGradientRelease(gradient);
     CGColorSpaceRelease(colorSpace);


### PR DESCRIPTION
Fixes the useAngle calculations so that they accurately render the proper angle, matching the web implementation.

Ports the [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/css_gradient_value.cc;l=883-952;bpv=1;bpt=1?q=linear-gradient%20lang:c%2B%2B&ss=chromium%2Fchromium%2Fsrc) to Java and Obj-C. I am not a Obj-C dev (first time), feedback greatly appreciated.

Concerns:
- How will the Chromium license affect consumers of the package? Do I need to include the Chromium copyright notice?
- This will break existing usage as it completely changes the way the points are calculated. Probably warrants a breaking change/major version?

In-depth writeup on the maths here: https://understandable.dev/deep-dives/react-native-linear-gradient/

Addresses #416 and #425 