### PR TITLE
Update changelog for 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,36 @@
 # ChangeLog
 
+## 2.6.1 - 2022-07-01
+
+- Allow react 17 as a peer dependency
+
 ## 2.6.0 - 2022-07-01
 
-- Update react-native to 0.60.5 (#435)
-- podspec target ios 9.0 (#427)
-- Adjust AnimatedGradient path on README.md (#439)
-- Update Android Gradle plugin to 3.5.1 (#441)
-- Update Android Gradle plugin to 3.5.2 (#445)
-- docs || RN ==> 0.60 support autolinking (#446)
-- Correct structure for Android installation (#450)
-- Update Android Gradle plugin to 3.5.3 (#460)
-- Add Troubleshooting section to README (#478)
-- Add transparent color example to README (#479)
-- Format README (#480)
-- Update README.md (#492)
-- Update React dependency in podspec (#500)
-- Improve flow types (#491)
-- Adds missing quotes in README (#516)
-- Update broken links in README (#524)
-- remove buildToolsVersion (#534)
-- Re-implement Windows support using C++ (#532)
-- Adding mavenCentral() as jcenter() is shutting (#527)
-- Enable basic GitHub Actions CI (#548)
-- Apply default Android Studio formatter (#549)
-- Fix useAngle logic to accurately render the angle (#547)
-- Add current latest release (2.5.6) in changelog (#531)
-- Update CI Node.js test matrix (#562)
-- Add GitHub Actions publish workflow (#561)
+- Update react-native to 0.60.5
+- podspec target ios 9.0
+- Adjust AnimatedGradient path on README.md
+- Update Android Gradle plugin to 3.5.1
+- Update Android Gradle plugin to 3.5.2
+- docs || RN ==> 0.60 support autolinking
+- Correct structure for Android installation
+- Update Android Gradle plugin to 3.5.3
+- Add Troubleshooting section to README
+- Add transparent color example to README
+- Format README
+- Update README.md
+- Update React dependency in podspec
+- Improve flow types
+- Adds missing quotes in README
+- Update broken links in README
+- remove buildToolsVersion
+- Re-implement Windows support using C++
+- Adding mavenCentral() as jcenter() is shutting
+- Enable basic GitHub Actions CI
+- Apply default Android Studio formatter
+- Fix useAngle logic to accurately render the angle
+- Add current latest release (2.5.6) in changelog
+- Update CI Node.js test matrix
+- Add GitHub Actions publish workflow
 
 ## 2.5.6 - 2019-07-25
 


### PR DESCRIPTION
This also removes PR numbers (added in #563) from plain text changelog, which are not hyperlinked anyway.
For more details including linked PR numbers, check the release page:
https://github.com/react-native-linear-gradient/react-native-linear-gradient/releases