### PR TITLE
Relax peerDependencies restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.8.1 || ^17",
-    "react-native": ">=0.55"
+    "react": "*",
+    "react-native": "*"
   },
   "devDependencies": {
     "flow-bin": "^0.98",


### PR DESCRIPTION
Allow any version of `react` and `react-native` in `peerDependencies`. This avoids potential errors/warnings when installing and/or adding this package as a dependency, and is in line with what most RN library templates specify.

Fixes #567 