### PR TITLE
Fix start/end point/position naming inconsistency

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientManager.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientManager.java
@@ -9,8 +9,8 @@ public class LinearGradientManager extends SimpleViewManager<LinearGradientView>
     public static final String REACT_CLASS = "BVLinearGradient";
     public static final String PROP_COLORS = "colors";
     public static final String PROP_LOCATIONS = "locations";
-    public static final String PROP_START_POS = "startPoint";
-    public static final String PROP_END_POS = "endPoint";
+    public static final String PROP_START_POINT = "startPoint";
+    public static final String PROP_END_POINT = "endPoint";
     public static final String PROP_USE_ANGLE = "useAngle";
     public static final String PROP_ANGLE_CENTER = "angleCenter";
     public static final String PROP_ANGLE = "angle";
@@ -38,14 +38,14 @@ public class LinearGradientManager extends SimpleViewManager<LinearGradientView>
         }
     }
 
-    @ReactProp(name = PROP_START_POS)
-    public void setStartPosition(LinearGradientView gradientView, ReadableArray startPos) {
-        gradientView.setStartPosition(startPos);
+    @ReactProp(name = PROP_START_POINT)
+    public void setStartPoint(LinearGradientView gradientView, ReadableArray startPoint) {
+        gradientView.setStartPoint(startPoint);
     }
 
-    @ReactProp(name = PROP_END_POS)
-    public void setEndPosition(LinearGradientView gradientView, ReadableArray endPos) {
-        gradientView.setEndPosition(endPos);
+    @ReactProp(name = PROP_END_POINT)
+    public void setEndPoint(LinearGradientView gradientView, ReadableArray endPoint) {
+        gradientView.setEndPoint(endPoint);
     }
 
     @ReactProp(name = PROP_USE_ANGLE, defaultBoolean = false)

--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientManager.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientManager.java
@@ -1,6 +1,7 @@
 package com.BV.LinearGradient;
 
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
@@ -39,12 +40,12 @@ public class LinearGradientManager extends SimpleViewManager<LinearGradientView>
     }
 
     @ReactProp(name = PROP_START_POINT)
-    public void setStartPoint(LinearGradientView gradientView, ReadableArray startPoint) {
+    public void setStartPoint(LinearGradientView gradientView, ReadableMap startPoint) {
         gradientView.setStartPoint(startPoint);
     }
 
     @ReactProp(name = PROP_END_POINT)
-    public void setEndPoint(LinearGradientView gradientView, ReadableArray endPoint) {
+    public void setEndPoint(LinearGradientView gradientView, ReadableMap endPoint) {
         gradientView.setEndPoint(endPoint);
     }
 
@@ -54,7 +55,7 @@ public class LinearGradientManager extends SimpleViewManager<LinearGradientView>
     }
 
     @ReactProp(name = PROP_ANGLE_CENTER)
-    public void setAngleCenter(LinearGradientView gradientView, ReadableArray in) {
+    public void setAngleCenter(LinearGradientView gradientView, ReadableMap in) {
         gradientView.setAngleCenter(in);
     }
 

--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
@@ -2,6 +2,7 @@ package com.BV.LinearGradient;
 
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.uimanager.PixelUtil;
 
@@ -125,13 +126,13 @@ public class LinearGradientView extends View {
         return new float[]{startX, startY};
     }
 
-    public void setStartPoint(ReadableArray startPoint) {
-        mStartPoint = new float[]{(float) startPoint.getDouble(0), (float) startPoint.getDouble(1)};
+    public void setStartPoint(ReadableMap startPoint) {
+        mStartPoint = new float[]{(float) startPoint.getDouble("x"), (float) startPoint.getDouble("y")};
         drawGradient();
     }
 
-    public void setEndPoint(ReadableArray endPoint) {
-        mEndPoint = new float[]{(float) endPoint.getDouble(0), (float) endPoint.getDouble(1)};
+    public void setEndPoint(ReadableMap endPoint) {
+        mEndPoint = new float[]{(float) endPoint.getDouble("x"), (float) endPoint.getDouble("y")};
         drawGradient();
     }
 
@@ -161,8 +162,8 @@ public class LinearGradientView extends View {
         drawGradient();
     }
 
-    public void setAngleCenter(ReadableArray in) {
-        mAngleCenter = new float[]{(float) in.getDouble(0), (float) in.getDouble(1)};
+    public void setAngleCenter(ReadableMap in) {
+        mAngleCenter = new float[]{(float) in.getDouble("x"), (float) in.getDouble("y")};
         drawGradient();
     }
 

--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
@@ -21,8 +21,8 @@ public class LinearGradientView extends View {
     private LinearGradient mShader;
 
     private float[] mLocations;
-    private float[] mStartPos = {0, 0};
-    private float[] mEndPos = {0, 1};
+    private float[] mStartPoint = {0, 0};
+    private float[] mEndPoint = {0, 1};
     private int[] mColors;
     private boolean mUseAngle = false;
     private float[] mAngleCenter = new float[]{0.5f, 0.5f};
@@ -125,13 +125,13 @@ public class LinearGradientView extends View {
         return new float[]{startX, startY};
     }
 
-    public void setStartPosition(ReadableArray startPos) {
-        mStartPos = new float[]{(float) startPos.getDouble(0), (float) startPos.getDouble(1)};
+    public void setStartPoint(ReadableArray startPoint) {
+        mStartPoint = new float[]{(float) startPoint.getDouble(0), (float) startPoint.getDouble(1)};
         drawGradient();
     }
 
-    public void setEndPosition(ReadableArray endPos) {
-        mEndPos = new float[]{(float) endPos.getDouble(0), (float) endPos.getDouble(1)};
+    public void setEndPoint(ReadableArray endPoint) {
+        mEndPoint = new float[]{(float) endPoint.getDouble(0), (float) endPoint.getDouble(1)};
         drawGradient();
     }
 
@@ -193,8 +193,8 @@ public class LinearGradientView extends View {
         if (mColors == null || (mLocations != null && mColors.length != mLocations.length))
             return;
 
-        float[] startPos;
-        float[] endPos;
+        float[] startPoint;
+        float[] endPoint;
 
         if (mUseAngle && mAngleCenter != null) {
             // Angle is in bearing degrees (North = 0, East = 90)
@@ -209,25 +209,25 @@ public class LinearGradientView extends View {
             };
             // Translate to center on angle center
             // Flip Y coordinate to convert from cartesian
-            startPos = new float[]{
+            startPoint = new float[]{
                     angleCenter[0] + relativeStartPoint[0],
                     angleCenter[1] - relativeStartPoint[1]
             };
             // Reflect across the center to get the end point
-            endPos = new float[]{
+            endPoint = new float[]{
                     angleCenter[0] - relativeStartPoint[0],
                     angleCenter[1] + relativeStartPoint[1]
             };
         } else {
-            startPos = new float[]{mStartPos[0] * mSize[0], mStartPos[1] * mSize[1]};
-            endPos = new float[]{mEndPos[0] * mSize[0], mEndPos[1] * mSize[1]};
+            startPoint = new float[]{mStartPoint[0] * mSize[0], mStartPoint[1] * mSize[1]};
+            endPoint = new float[]{mEndPoint[0] * mSize[0], mEndPoint[1] * mSize[1]};
         }
 
         mShader = new LinearGradient(
-                startPos[0],
-                startPos[1],
-                endPos[0],
-                endPos[1],
+                startPoint[0],
+                startPoint[1],
+                endPoint[0],
+                endPoint[1],
                 mColors,
                 mLocations,
                 Shader.TileMode.CLAMP);

--- a/index.android.js
+++ b/index.android.js
@@ -13,10 +13,11 @@ const convertPoint = (name, point) => {
       `LinearGradient '${name}' property should be an object with fields 'x' and 'y', ` +
       'Array type is deprecated.'
     );
-  }
-  // TODO: Update Android native code to receive a {x, y} object, not an array
-  if (point !== null && typeof point === 'object') {
-    return [point.x, point.y];
+
+    return {
+      x: point[0],
+      y: point[1]
+    };
   }
   return point;
 };


### PR DESCRIPTION
This fixes two issues with the way points were set on Android. The methods in the view manager were called "setStartPosition" instead of "setStartPoint" etc. There was also an issue/inconsistency with the way a point was transferred from JS to native (Array vs Map) - This had been marked with a `// TODO` for a long time. Thanks @Sunbreak for the fix (I cherry-picked your commit).