### PR TITLE
Prepare build.gradle and Podspec for new architecture

### DIFF
--- a/BVLinearGradient.podspec
+++ b/BVLinearGradient.podspec
@@ -1,6 +1,8 @@
 require 'json'
 version = JSON.parse(File.read('package.json'))["version"]
 
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+
 Pod::Spec.new do |s|
 
   s.name            = "BVLinearGradient"
@@ -12,10 +14,31 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.source          = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "v#{s.version}" }
-  s.source_files    = 'ios/*.{h,m}'
+  s.source_files    = 'ios/*.{h,m,mm}'
   s.preserve_paths  = "**/*.js"
   s.frameworks = 'UIKit', 'QuartzCore', 'Foundation'
 
-  s.dependency 'React-Core'
+  # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
+  # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
+  if respond_to?(:install_modules_dependencies, true)
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
 
+    # Don't install the dependencies when we run `pod install` in the old architecture.
+    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
+      s.dependency "React-RCTFabric"
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
+  end
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,9 +3,12 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    // The Android Gradle plugin is only required when opening the android folder stand-alone.
-    // This avoids unnecessary downloads and potential conflicts when the library is included as a
-    // module dependency in an application project.
+    ext.isNewArchitectureEnabled = () ->
+            rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+
+    // buildscript dependencies are only required when working with the module in isolation (e.g.
+    // during development and for testing). This avoids unnecessary downloads and potential
+    // conflicts when the library is included as a module dependency in an application project.
     if (project == rootProject) {
         repositories {
             google()
@@ -13,17 +16,25 @@ buildscript {
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:7.2.1'
+            if (isNewArchitectureEnabled()) {
+                classpath 'com.facebook.react:react-native-gradle-plugin'
+            }
         }
     }
 }
 
 apply plugin: 'com.android.library'
 
+if (isNewArchitectureEnabled()) {
+    apply plugin: "com.facebook.react"
+}
+
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 31).toInteger()
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 31)
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }
     lintOptions {
         abortOnError false


### PR DESCRIPTION
The changes to both files (build.gradle and Podspec) in this PR are minimal and fully backwards compatible (i.e. they will not have any effect on older versions). Therefore we can merge them before the rest of the changes, in preparation for release 3.0.0 (with full support for the new architecture).