### PR TITLE
Re-add missing generic type argument for Java 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 }
 
 repositories {

--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientPackage.java
@@ -20,6 +20,6 @@ public class LinearGradientPackage implements ReactPackage {
     @NonNull
     @Override
     public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
-        return Collections.singletonList(new LinearGradientManager());
+        return Collections.<ViewManager>singletonList(new LinearGradientManager());
     }
 }


### PR DESCRIPTION
Older React Native versions use a version of the Android Gradle Plugin that does not yet default to Java 8, which means the type argument cannot be inferred automatically. This resulted in a compile error on RN 0.64 (see #623). The solution is to re-add the type argument, and also set compile options to Java 7 in order to avoid these type of issues in the future.

The argument was accidentally removed in #607 (specifically 56ca2cb).

This fix will be published as a patch release 2.8.1, which will restore compatibility with React Native versions <0.68.

Fixes #623