### PR TITLE
Modernize BVLinearGradientLayer to use UIGraphicsImageRenderer if on supported OS versions

### DIFF
--- a/ios/BVLinearGradientLayer.m
+++ b/ios/BVLinearGradientLayer.m
@@ -60,15 +60,32 @@
         hasAlpha = hasAlpha || CGColorGetAlpha(self.colors[i].CGColor) < 1.0;
     }
 
-    UIGraphicsBeginImageContextWithOptions(self.bounds.size, !hasAlpha, 0.0);
-    CGContextRef ref = UIGraphicsGetCurrentContext();
-    [self drawInContext:ref];
+    if (@available(iOS 10.0, *)) {
+        UIGraphicsImageRendererFormat *format;
+        if (@available(iOS 11.0, *)) {
+            format = [UIGraphicsImageRendererFormat preferredFormat];
+        } else {
+            format = [UIGraphicsImageRendererFormat defaultFormat];
+        }
+        format.opaque = !hasAlpha;
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:self.bounds.size format:format];
+        UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull ref) {
+            [self drawInContext:ref.CGContext];
+        }];
 
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    self.contents = (__bridge id _Nullable)(image.CGImage);
-    self.contentsScale = image.scale;
+        self.contents = (__bridge id _Nullable)(image.CGImage);
+        self.contentsScale = image.scale;
+    } else {
+        UIGraphicsBeginImageContextWithOptions(self.bounds.size, !hasAlpha, 0.0);
+        CGContextRef ref = UIGraphicsGetCurrentContext();
+        [self drawInContext:ref];
 
-    UIGraphicsEndImageContext();
+        UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+        self.contents = (__bridge id _Nullable)(image.CGImage);
+        self.contentsScale = image.scale;
+
+        UIGraphicsEndImageContext();
+    }
 }
 
 - (void)setUseAngle:(BOOL)useAngle


### PR DESCRIPTION
When running on Xcode 15 against iOS 17 I'm getting a crash. It seems like the error message suggests `UIGraphicsBeginImageContext` isn't supported anymore and that we need to update to use `UIGraphicsImageRenderer` instead. I'm not sure if this assert only applies to specific cases internally, but I'm thinking it's probably a good idea to update to the more modern API anyways.

```
Thread 1: "UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={0, 6}, scale=3.000000, bitmapInfo=0x2006. Use UIGraphicsImageRenderer to avoid this assert."
```
<details>
<summary>Stack trace</summary>

```
*** Assertion failure in void _UIGraphicsBeginImageContextWithOptions(CGSize, BOOL, CGFloat, BOOL)(), UIGraphics.m:410
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={0, 6}, scale=3.000000, bitmapInfo=0x2006. Use UIGraphicsImageRenderer to avoid this assert.'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000180465ef8 __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x000000018005c0ac objc_exception_throw + 56
	2   Foundation                          0x0000000180caa400 -[NSMutableDictionary(NSMutableDictionary) classForCoder] + 0
	3   UIKitCore                           0x000000012e2f2d08 _UIGraphicsBeginImageContextWithOptions + 564
	4   MyAppFramework                      0x0000000119adf488 -[BVLinearGradientLayer display] + 576
	5   QuartzCore                          0x00000001884c4dec _ZN2CA5Layer28layout_and_display_if_neededEPNS_11TransactionE + 392
	6   QuartzCore                          0x00000001883dfc68 _ZN2CA7Context18commit_transactionEPNS_11TransactionEdPd + 460
	7   QuartzCore                          0x000000018840f65c _ZN2CA11Transaction6commitEv + 652
	8   QuartzCore                          0x0000000188410b10 _ZN2CA11Transaction25flush_as_runloop_observerEb + 68
	9   CoreFoundation                      0x00000001803c5cfc __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 32
	10  CoreFoundation                      0x00000001803c0700 __CFRunLoopDoObservers + 528
	11  CoreFoundation                      0x00000001803c0bb8 __CFRunLoopRun + 968
	12  CoreFoundation                      0x00000001803c03dc CFRunLoopRunSpecific + 572
	13  GraphicsServices                    0x0000000189bf5bc0 GSEventRunModal + 160
	14  UIKitCore                           0x000000012e737c70 -[UIApplication _run] + 868
	15  UIKitCore                           0x000000012e73b8d4 UIApplicationMain + 124
	16  MyApp                               0x000000010248cd38 main + 64
	17  dyld                                0x0000000110541558 start_sim + 20
	18  ???                                 0x0000000110629f28 0x0 + 4569866024
	19  ???                                 0x6d72800000000000 0x0 + 7886506634967515136
)
libc++abi: terminating due to uncaught exception of type NSException
```

</details>

I'd love some help testing this out to see if it changes any behaviours.

Fixes #618