### PR TITLE
Add prerelease GitHub Actions workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,52 @@
+name: prerelease
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'Release Type'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+          - premajor
+          - preminor
+          - prepatch
+          - prerelease
+      preid:
+        description: 'Prerelease Identifier'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - ''
+          - alpha
+          - beta
+          - rc
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Set Git user
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+      - run: npm version ${{ github.event.inputs.type }} --preid ${{ github.event.inputs.preid }}
+      - run: git push --follow-tags
+      - run: echo "VERSION=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
+      - name: Create Release Notes
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.request(`POST /repos/${{ github.repository }}/releases`, {
+              draft: true,
+              name: "${{ env.VERSION }}",
+              prerelease: true,
+              tag_name: "v${{ env.VERSION }}"
+            });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish --access public
+      - run: npm publish --tag ${{ github.event.release.prerelease && 'next' || 'latest' }} --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This adds a simple and minimal GitHub Actions workflow that enables **prerelease** builds. It uses `workflow_dispatch` trigger very similar to the **version** workflow (i.e. can be started manually on any branch).
The same **publish** workflow publishes the new prerelease version to npm. **publish** has been updated to automatically select between `latest` and `next` tags based on whether the GitHub release is marked as "pre-release" or not.

References:

- [npm version](https://docs.npmjs.com/cli/v8/commands/npm-version) for details on release types
- [npm dist-tag](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag) for info about the `next` tag

<img width="340" alt="image" src="https://github.com/react-native-linear-gradient/react-native-linear-gradient/assets/743291/f3c97bcf-124d-4947-a635-da4af71ed634">
