### PR TITLE
Fix build.gradle for RN 0.63-0.66 (Gradle 6.x)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,9 +3,9 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    ext.isNewArchitectureEnabled = () ->
-            rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
-
+    ext.isNewArchitectureEnabled = { _ ->
+        project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+    }
     // buildscript dependencies are only required when working with the module in isolation (e.g.
     // during development and for testing). This avoids unnecessary downloads and potential
     // conflicts when the library is included as a module dependency in an application project.


### PR DESCRIPTION
While testing the latest default branch, I noticed that b1f8532 (via #608) accidentally contained Groovy syntax that is not understood by Gradle 6.x, breaking the build in projects using RN 0.63-0.66 with default dependencies. Gradle was upgraded to 7.x only in RN 0.67.
Since b1f8532 has not been released yet no hotfix/patch is needed.