### PR TITLE
Remove compileOptions from build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,10 +39,6 @@ android {
     lintOptions {
         abortOnError false
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
-    }
 }
 
 repositories {


### PR DESCRIPTION
It turns out in the addition of compileOptions (via #624, released in `2.8.1`) could lead to compilation errors in some scenarios with certain versions of React Native.

This patch will also be released as `2.8.2`.

Fixes #627 
Also possibly related: #630