### PR TITLE
Fix Podspec name in files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "index.d.ts",
     "index.ios.js",
     "index.windows.js",
-    "react-native-linear-gradient.podspec"
+    "RNLinearGradient.podspec"
   ],
   "scripts": {
     "flow": "flow check"


### PR DESCRIPTION
RNLinearGradient.podspec was missing in the packaged bundle for 3.0.0-alpha.0