### PR TITLE
feat: added default color handling in process color if invalid string…

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -81,14 +81,18 @@ export default class LinearGradient extends Component<Props> {
       validRadius(flatStyle.borderBottomLeftRadius)
     ];
 
+    const filteredColor = colors.map((value) => {
+      return processColor(value) ?? processColor("#00000000");
+    });
+
     return (
       <View ref={this.gradientRef} {...otherProps} style={style}>
         <NativeLinearGradient
           style={{position: 'absolute', top: 0, left: 0, bottom: 0, right: 0}}
-          colors={colors.map(processColor)}
+          colors={filteredColor}
           startPoint={convertPoint('start', start)}
           endPoint={convertPoint('end', end)}
-          locations={locations ? locations.slice(0, colors.length) : null}
+          locations={locations ? locations.slice(0, filteredColor.length) : null}
           useAngle={useAngle}
           angleCenter={convertPoint('angleCenter', angleCenter)}
           angle={angle}


### PR DESCRIPTION
Issue Overview: 

The application experiences crashes under specific circumstances when an invalid color string is passed to the LinearGradient component. This occurs due to the internal mechanism of processColor, which is utilized by LinearGradient to convert color strings into integer values required by Android. When an invalid color string (e.g., "ffffff" without a preceding #) is supplied, processColor returns undefined, subsequently leading to a crash on the Android side due to the expected integer value not being provided.

The app crashes with following error:

![image](https://github.com/react-native-linear-gradient/react-native-linear-gradient/assets/85783438/a375b8e7-75fe-487d-9dcd-243565030894)



Added default color handling in case of invalid color string is passed to LinaerGradient component to prevent app crash