### PR TITLE
fix: react-native 0.74 processColor

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -3,7 +3,7 @@
  * @flow
  */
 import React, { Component, createRef } from 'react';
-import { processColor, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import NativeLinearGradient, { type Props } from './src';
 
@@ -85,7 +85,7 @@ export default class LinearGradient extends Component<Props> {
       <View ref={this.gradientRef} {...otherProps} style={style}>
         <NativeLinearGradient
           style={{position: 'absolute', top: 0, left: 0, bottom: 0, right: 0}}
-          colors={colors.map(processColor)}
+          colors={colors}
           startPoint={convertPoint('start', start)}
           endPoint={convertPoint('end', end)}
           locations={locations ? locations.slice(0, colors.length) : null}


### PR DESCRIPTION
## Description

This fixes #661 
In React Native 0.74, colors are processed by default. You can see this in the code-> [Link](https://github.com/facebook/react-native/blob/334b5c9fdb4ffb0c6d048dfce7e6b593ae79d10e/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js#L173-L174)
The errors are happening because React Native tries to process colors that have already been processed.

@friederbluemle