### PR TITLE
added namespace for AGP version 7+. This should fix compatibility iss…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,10 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace = "com.BV.LinearGradient"
+    }
     compileSdkVersion safeExtGet('compileSdkVersion', 31).toInteger()
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)


### PR DESCRIPTION
…ues with gradle 8.

this fixes issue [#665 ](https://github.com/react-native-linear-gradient/react-native-linear-gradient/issues/665)