### PR TITLE
fix: make props readonly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,27 @@
-declare module 'react-native-linear-gradient' {
-  import * as React from 'react';
-  import * as ReactNative from 'react-native';
+declare module "react-native-linear-gradient" {
+  import * as React from "react";
+  import * as ReactNative from "react-native";
 
-  export interface LinearGradientProps extends ReactNative.ViewProps {
-    colors: (string | number)[];
-    start?: { x: number; y: number };
-    end?: { x: number; y: number };
-    locations?: number[];
-    useAngle?: boolean;
-    angleCenter?: {x: number, y: number};
-    angle?: number;
-  }
+  type DeepReadonly<T> = Readonly<{
+    [K in keyof T]: T[K] extends number | string | symbol // Is it a primitive? Then make it readonly
+      ? Readonly<T[K]>
+      : // Is it an array of items? Then make the array readonly and the item as well
+        T[K] extends Array<infer A>
+        ? Readonly<Array<DeepReadonly<A>>>
+        : // It is some other object, make it readonly as well
+          DeepReadonly<T[K]>;
+  }>;
+
+  export type LinearGradientProps = ReactNative.ViewProps &
+    DeepReadonly<{
+      colors: (string | number)[];
+      start?: { x: number; y: number };
+      end?: { x: number; y: number };
+      locations?: number[];
+      useAngle?: boolean;
+      angleCenter?: { x: number; y: number };
+      angle?: number;
+    }>;
 
   export class LinearGradient extends React.Component<LinearGradientProps> {}
 


### PR DESCRIPTION
Hi,

Currently if you want to pass a readonly variable to a prop, you would get an error.
For example `const colors = ['red', 'blue'] as const` and then set that as the colors props, then a ts error would show up because colors is defined as constant but the props type are not.

Note that flow types are readonly already:
https://github.com/react-native-linear-gradient/react-native-linear-gradient/blob/2d67c42e2935bb1da425f1f890bcaf64594806d5/src/RNLinearGradientNativeComponent.js#L10-L20

but not ts types:
https://github.com/react-native-linear-gradient/react-native-linear-gradient/blob/2d67c42e2935bb1da425f1f890bcaf64594806d5/index.d.ts#L5-L13



credits to [this blog post](https://dev.to/bwca/deep-readonly-generic-in-typescript-4b04) for the deep readonly utility