### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['16', '18', '20']
+        node: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: ${{ matrix.node }}
@@ -20,11 +20,11 @@ jobs:
   build-android-oldarch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/gradle-build-action@v2
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: 7.5.1
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
       - run: yarn --frozen-lockfile
@@ -33,11 +33,11 @@ jobs:
   build-android-newarch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/gradle-build-action@v2
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: 7.5.1
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
       - run: yarn --frozen-lockfile
@@ -49,32 +49,32 @@ jobs:
   build-ios-oldarch:
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
       - run: yarn --frozen-lockfile
-      - run: curl https://raw.githubusercontent.com/fbtmp/rn-native-module-support/d95b3f90dd9212227f5a51a1c758252afdeb1161/Podfile -o ios/Podfile
+      - run: curl https://raw.githubusercontent.com/fbtmp/rn-native-module-support/f59016ca9666acfd413bfe295717171067a57171/Podfile -o ios/Podfile
       - working-directory: ios/
         run: pod install
       - run: xcodebuild -workspace "ios/RNLinearGradient.xcworkspace" -scheme "RNLinearGradient" -destination "platform=iOS Simulator,name=iPhone 14"
   build-ios-newarch:
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
       - run: yarn --frozen-lockfile
-      - run: curl https://raw.githubusercontent.com/fbtmp/rn-native-module-support/d95b3f90dd9212227f5a51a1c758252afdeb1161/Podfile -o ios/Podfile
+      - run: curl https://raw.githubusercontent.com/fbtmp/rn-native-module-support/f59016ca9666acfd413bfe295717171067a57171/Podfile -o ios/Podfile
       - working-directory: ios/
         run: RCT_NEW_ARCH_ENABLED=1 pod install
       - run: xcodebuild -workspace "ios/RNLinearGradient.xcworkspace" -scheme "RNLinearGradient" -destination "platform=iOS Simulator,name=iPhone 14"
   integration-rn68:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: 16

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,27 +26,24 @@ jobs:
   prerelease:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
-      - name: Set Git user
-        run: |
+          node-version: 20
+      - run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - run: npm version ${{ github.event.inputs.type }} --preid ${{ github.event.inputs.preid }}
+      - run: |
+          if [ -z "${{ github.event.inputs.preid }}" ]; then
+            npm version ${{ github.event.inputs.type }}
+          else
+            npm version ${{ github.event.inputs.type }} --preid ${{ github.event.inputs.preid }}
+          fi
       - run: git push --follow-tags
       - run: echo "VERSION=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
-      - name: Create Release Notes
-        uses: actions/github-script@v6
-        with:
-          script: |
-            await github.request(`POST /repos/${{ github.repository }}/releases`, {
-              draft: true,
-              name: "${{ env.VERSION }}",
-              prerelease: true,
-              tag_name: "v${{ env.VERSION }}"
-            });
+      - run: gh release create v${VERSION} -d --generate-notes -p -t ${VERSION}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --tag ${{ github.event.release.prerelease && 'next' || 'latest' }} --access public
         env:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,27 +15,19 @@ jobs:
   version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
-      - name: Set Git user
-        run: |
+          node-version: 20
+      - run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - run: npm version ${{ github.event.inputs.type }}
       - run: git push --follow-tags
       - run: echo "VERSION=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
-      - name: Create Release Notes
-        uses: actions/github-script@v6
-        with:
-          script: |
-            await github.request(`POST /repos/${{ github.repository }}/releases`, {
-              draft: true,
-              generate_release_notes: true,
-              name: "${{ env.VERSION }}",
-              tag_name: "v${{ env.VERSION }}"
-            });
+      - run: gh release create v${VERSION} -d --generate-notes -t ${VERSION}
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This updates GitHub Actions workflows to use newer versions of actions and node, as well as some minor improvements/simplifications to the release process (e.g. directly run `gh release create` instead of using raw actions/github-script).