### PR TITLE
Add minimal Jest mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ You can see this component in action in [brentvatne/react-native-login](https://
 1. Ensure to run `pod install` before running the app on iOS
 2. Ensure you use `ios/**.xcworkspace` file instead of `ios./**.xcodeproj`
 
+### Testing with Jest
+
+If you do not have a Jest Setup file configured, you should add the following to your Jest settings and create the jest.setup.js file in project root:
+
+```js
+setupFiles: ['<rootDir>/jest.setup.js'];
+```
+
+You should then add the following to your Jest setup file to mock the LinearGradient Native Module:
+
+```js
+import mockRNLinearGradient from 'react-native-linear-gradient/jest/linear-gradient-mock';
+
+jest.mock('react-native-linear-gradient', () => mockRNLinearGradient);
+```
+
 ### Other
 
 Clearing build caches and reinstalling dependencies sometimes solve some issues. Try next steps:

--- a/jest/linear-gradient-mock.js
+++ b/jest/linear-gradient-mock.js
@@ -1,0 +1,3 @@
+const RNLinearGradientMock = 'RNLinearGradientMock';
+
+module.exports = RNLinearGradientMock;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "android",
     "ios",
+    "jest",
     "src",
     "windows",
     "index.android.js",


### PR DESCRIPTION
This introduces a new minimal testing setup for Jest, adds a Jest mock for the `react-native-linear-gradient` module, and includes the `jest` directory in the package files.