### PR TITLE
Simplify and fix GradientTimer (example)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: yarn --frozen-lockfile
       - run: yarn flow
+      - working-directory: example/
+        run: |
+          yarn --frozen-lockfile
+          yarn test
   build-android-oldarch:
     runs-on: ubuntu-latest
     steps:

--- a/example/__tests__/App-test.tsx
+++ b/example/__tests__/App-test.tsx
@@ -9,6 +9,7 @@ import App from '../src/App';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
-it('renders correctly', () => {
-  renderer.create(<App />);
+it('renders', () => {
+  const app = renderer.create(<App />);
+  app.unmount();
 });

--- a/example/jest.config.js
+++ b/example/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'react-native',
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)/)',
+  ],
+};

--- a/example/jest.setup.js
+++ b/example/jest.setup.js
@@ -1,0 +1,5 @@
+/* eslint-env jest */
+
+import mockRNLinearGradient from '../jest/linear-gradient-mock';
+
+jest.mock('react-native-linear-gradient', () => mockRNLinearGradient);

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "ios": "react-native run-ios",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "start": "react-native start",
-    "test": "jest --passWithNoTests"
+    "test": "jest"
   },
   "dependencies": {
     "@react-native-community/slider": "^4.4.2",
@@ -36,16 +36,5 @@
   },
   "resolutions": {
     "@types/react": "^17"
-  },
-  "jest": {
-    "preset": "react-native",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ]
   }
 }


### PR DESCRIPTION
The timer setup in the `GradientTimer` example component had some subtle bugs. This rewrites most of the logic and removes the custom `useInterval` hook. Overall much simpler, with the added ability to pause/resume gradient animation.

In a separate commit, this also fixes the test setup in the example/ folder (using mock added in #680), and adds a basic `yarn test` check to the CI workflow.